### PR TITLE
Add assertions to check validity of index

### DIFF
--- a/src/main/java/odin/parser/command/AddCommand.java
+++ b/src/main/java/odin/parser/command/AddCommand.java
@@ -45,9 +45,7 @@ public abstract class AddCommand implements Command {
      * @return String obtained by concatenating the tokens with spaces in between.
      */
     protected static String concatBySpace(ArrayList<String> tokens, int l, int r) {
-        if (!(0 <= l && l < r && r <= tokens.size())) {
-            throw new RuntimeException("concatBySpace: invalid range");
-        }
+        assert 0 <= l && l < r && r <= tokens.size() : "indexes should represent a valid range";
         StringBuilder sb = new StringBuilder();
         for (int i = l; i < r; i++) {
             if (i > l) {

--- a/src/main/java/odin/parser/command/DeleteCommand.java
+++ b/src/main/java/odin/parser/command/DeleteCommand.java
@@ -15,6 +15,7 @@ public class DeleteCommand extends ManipulateCommand {
 
     @Override
     void manipulate() {
+        assert 1 <= this.idx && this.idx <= taskList.getSize() : "index should be between 1 and the size of task list";
         this.deletedTaskDescription = this.taskList.getTaskDescription(this.idx - 1);
         this.taskList.delete(this.idx - 1);
     }

--- a/src/main/java/odin/parser/command/FindCommand.java
+++ b/src/main/java/odin/parser/command/FindCommand.java
@@ -54,6 +54,7 @@ public class FindCommand implements Command {
             messages.add(String.format("These are the tasks that contain the keyword(s) '%s'.", this.pattern));
             int j = 1;
             for (int i : this.matchIndexes) {
+                assert 0 <= i && i < this.taskList.getSize() : "index should be between 0 and size minus 1";
                 messages.add(String.format("%d. %s", j, this.taskList.getTaskDescription(i)));
                 j += 1;
             }

--- a/src/main/java/odin/parser/command/MarkCommand.java
+++ b/src/main/java/odin/parser/command/MarkCommand.java
@@ -13,6 +13,7 @@ public class MarkCommand extends ManipulateCommand {
 
     @Override
     void manipulate() {
+        assert 1 <= this.idx && this.idx <= taskList.getSize() : "index should be between 1 and the size of task list";
         this.taskList.markAsDone(this.idx - 1);
     }
 

--- a/src/main/java/odin/parser/command/UnmarkCommand.java
+++ b/src/main/java/odin/parser/command/UnmarkCommand.java
@@ -13,6 +13,7 @@ public class UnmarkCommand extends ManipulateCommand {
 
     @Override
     void manipulate() {
+        assert 1 <= this.idx && this.idx <= taskList.getSize() : "index should be between 1 and the size of task list";
         this.taskList.markAsNotDone(this.idx - 1);
     }
 


### PR DESCRIPTION
There are multiple command classes with a method that takes in indexes as arguments, without checking their validity.

Even though these indexes are guaranteed to be valid if everything is implemented correctly, it is better to use assertions in order to ensure and demonstrate the validity.

Let's put assertions, in every function that takes in indexes as arguments, to check their validity.